### PR TITLE
restartPolicy: OnFailure

### DIFF
--- a/deploy/60-osd-ready.Job.yaml
+++ b/deploy/60-osd-ready.Job.yaml
@@ -4,8 +4,6 @@ metadata:
     name: osd-cluster-ready
     namespace: openshift-monitoring
 spec:
-    activeDeadlineSeconds: 3900 # 1 hour for the silence, 5 minutes for processing/data completion
-    backoffLimit: 0
     template:
         metadata:
             name: osd-cluster-ready
@@ -20,5 +18,5 @@ spec:
               name: osd-cluster-ready
               image: quay.io/openshift-sre/osd-cluster-ready
               command: ["/root/main"]
-            restartPolicy: Never
+            restartPolicy: OnFailure
             serviceAccountName: osd-cluster-ready


### PR DESCRIPTION
Change the `restartPolicy` to `OnFailure` so that the job will restart if errors occur. Remove the overrides for `backoffLimit` and `activeDeadlineSeconds` to let the defaults for those take over.

(Note that this is not really related to the maximum cluster age observed by the job. The job only fails if an error occurs, not if health checks are unsuccessful. They tie together only in the sense that, if the job restarts after one or more failures, it still uses the inception of the cluster (not the job) to determine the maximum age.)